### PR TITLE
set focus on first input of type=number

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -72,7 +72,7 @@ function focusEventTarget(evt) {
 
 document.addEventListener('DOMContentLoaded', async function() { 
   let settings = await browser.runtime.sendMessage({ type: 'getSettings' }) || {};
-  document.getElementById('blur').focus();
+  document.getElementById('blurValueText').focus();
   updateValue('blur', settings.blurLevel || 0);
   updateValue('contrast', settings.contrastLevel || 0);
   updateValue('brightness', settings.brightnessLevel || 0);


### PR DESCRIPTION
### Updates:
- Changed initial focus from slider to input of type=number. (Keyboard users cannot only interact with the input, not the slider.)